### PR TITLE
add education group to owners of cookbook_gallery.txt file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 # GLOBAL OWNER
 *   @ProjectPythiaCookbooks/infrastructure
+
+site/cookbook_gallery.txt @ProjectPythiaCookbooks/education


### PR DESCRIPTION
Everything in this repository is infrastructure. Except the `cookbook_gallery.txt` file that approves which Cookbooks are displayed in the gallery, that is managed by the education team. I updated CODEOWNERS to reflect that.