### PR TITLE
Add PR writing permissions to actions

### DIFF
--- a/.github/workflows/update-cookbook-gallery.yaml
+++ b/.github/workflows/update-cookbook-gallery.yaml
@@ -63,6 +63,8 @@ jobs:
 
   create-pull-request:
     needs: validate-user-submission
+    permissions: 
+      pull-requests: write
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Opening an issue from the new cookbook template fails to generate a new PR with this error code:

  ```
To https://github.com/ProjectPythiaCookbooks/projectpythiacookbooks.github.io
   ! [remote rejected] HEAD -> cookbook-gallery-62 (refusing to allow a GitHub App to create or update workflow `.github/workflows/collect-user-submission.py` without `workflows` permission)
  error: failed to push some refs to 'https://github.com/ProjectPythiaCookbooks/projectpythiacookbooks.github.io'
  Error: The process '/usr/bin/git' failed with exit code 1
```

I'm trying to give the workflows permission.