### PR TITLE
Fix Cookbook landing links and test removing old config

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -11,7 +11,6 @@ jobs:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
       environment_file: 'environment.yml'
-      environment_name: pythia-tutorial-dev
       path_to_notebooks: 'site'
       build_command: 'make -j4 html'
 

--- a/.github/workflows/trigger-site-build.yaml
+++ b/.github/workflows/trigger-site-build.yaml
@@ -7,7 +7,6 @@ jobs:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
       environment_file: 'environment.yml'
-      environment_name: pythia-tutorial-dev
       artifact_name: book-zip-${{ github.event.number }}
       path_to_notebooks: 'site'
       build_command: 'make -j4 html'

--- a/environment.yml
+++ b/environment.yml
@@ -1,12 +1,9 @@
-name: pythia-tutorial-dev
+name: pythia-gallery
 channels:
 - conda-forge
-- nodefaults
 dependencies:
 - cffconvert
-- matplotlib
 - myst-nb
-- pandas
 - pre-commit
 - pyyaml
 - sphinx-pythia-theme

--- a/site/_extensions/gallery_generator.py
+++ b/site/_extensions/gallery_generator.py
@@ -59,36 +59,22 @@ def generate_repo_dicts(all_items):
         github_url = f"https://github.com/ProjectPythia/{repo}"
         cookbook_url = f"https://projectpythia.org/{repo}/"
 
-        try:
-            citation_url = f"https://raw.githubusercontent.com/ProjectPythia/{repo}/main/CITATION.cff"
-            cffconvert_command = f"cffconvert -f zenodo -u {citation_url}"
-            citation_dict = _run_cffconvert(cffconvert_command)
+        citation_url = f"https://raw.githubusercontent.com/ProjectPythia/{repo}/main/CITATION.cff"
+        cffconvert_command = f"cffconvert -f zenodo -u {citation_url}"
+        citation_dict = _run_cffconvert(cffconvert_command)
 
-            cookbook_title = citation_dict["title"]
-            description = citation_dict["description"]
-            creators = citation_dict["creators"]
-            names = [_make_standard_name(creator.get("name")) for creator in creators]
-            authors = ", ".join(names)
+        cookbook_title = citation_dict["title"]
+        description = citation_dict["description"]
+        creators = citation_dict["creators"]
+        names = [_make_standard_name(creator.get("name")) for creator in creators]
+        authors = ", ".join(names)
 
-            gallery_info_url = f"https://raw.githubusercontent.com/ProjectPythia/{repo}/main/_gallery_info.yml"
-            gallery_info_dict = yaml.safe_load(requests.get(gallery_info_url).content)
-            thumbnail = gallery_info_dict["thumbnail"]
-            tag_dict = {
-                k: v for k, v in gallery_info_dict["tags"].items() if (v is not None and v[0] is not None)
-            }
-
-        except:
-            config_url = f"https://raw.githubusercontent.com/ProjectPythia/{repo}/main/_config.yml"
-            config = requests.get(config_url).content
-            config_dict = yaml.safe_load(config)
-
-            cookbook_title = config_dict["title"]
-            description = config_dict["description"]
-            authors = config_dict["author"]
-            thumbnail = config_dict["thumbnail"]
-            tag_dict = {
-                k: v for k, v in config_dict["tags"].items() if (v is not None and v[0] is not None)
-            }
+        gallery_info_url = f"https://raw.githubusercontent.com/ProjectPythia/{repo}/main/_gallery_info.yml"
+        gallery_info_dict = yaml.safe_load(requests.get(gallery_info_url).content)
+        thumbnail = gallery_info_dict["thumbnail"]
+        tag_dict = {
+            k: v for k, v in gallery_info_dict["tags"].items() if (v is not None and v[0] is not None)
+        }
 
         repo_dict = {
             "repo": repo,

--- a/site/_extensions/gallery_generator.py
+++ b/site/_extensions/gallery_generator.py
@@ -2,27 +2,10 @@ import itertools, json, yaml, pathlib, subprocess, requests
 from truncatehtml import truncate
 import re
 
-
-def _grab_binder_link(repo):
-    config_url = (
-        f"https://raw.githubusercontent.com/ProjectPythia/{repo}/main/_config.yml"
-    )
-    config = requests.get(config_url).content
-    config_dict = yaml.safe_load(config)
-    root = config_dict["sphinx"]["config"]["html_theme_options"]["launch_buttons"][
-        "binderhub_url"
-    ]
-    end = f"/v2/gh/ProjectPythia/{repo}.git/main"
-    url = root + end
-    return root, url
-
-
 def _generate_status_badge_html(repo, github_url):
-    binder_root, binder_link = _grab_binder_link(repo)
     github_id = _grab_github_id(repo)
     return f"""
     <a class="reference external" href="{github_url}/actions/workflows/nightly-build.yaml"><img alt="nightly-build" src="{github_url}/actions/workflows/nightly-build.yaml/badge.svg" /></a>
-    <a class="reference external" href="{binder_link}"><img alt="Binder" src="{binder_root}/badge_logo.svg" /></a>
     <a class="reference external" href="https://zenodo.org/badge/latestdoi/{github_id}"><img alt="DOI" src="https://zenodo.org/badge/{github_id}.svg" /></a>
     """
 

--- a/site/_extensions/gallery_generator.py
+++ b/site/_extensions/gallery_generator.py
@@ -57,7 +57,7 @@ def generate_repo_dicts(all_items):
     for item in all_items:
         repo = item.strip()
         github_url = f"https://github.com/ProjectPythia/{repo}"
-        cookbook_url = f"https://projectpythia.org/{repo}/README.html"
+        cookbook_url = f"https://projectpythia.org/{repo}/"
 
         try:
             citation_url = f"https://raw.githubusercontent.com/ProjectPythia/{repo}/main/CITATION.cff"

--- a/site/conf.py
+++ b/site/conf.py
@@ -108,7 +108,6 @@ html_theme_options = {
         {"name": "Cookbooks", "url": "https://cookbooks.projectpythia.org/"},
         {"name": "Resources", "url": "https://projectpythia.org/resource-gallery.html"},
         {"name": "Community", "url": "https://projectpythia.org/#join-us"},
-        {"name": "Blog", "url": "https://projectpythia.org/blog.html"},
     ],
     'navbar_end': ['navbar-icon-links'],
     "page_layouts": {

--- a/site/cookbook_gallery_subtext.md
+++ b/site/cookbook_gallery_subtext.md
@@ -1,4 +1,4 @@
-Pythia Cookbooks provide example workflows on more advanced and domain-specific problems developed by the Pythia community. Cookbooks build on top of skills you learn in [Pythia Foundations](https://foundations.projectpythia.org/landing-page.html).
+Pythia Cookbooks provide example workflows on more advanced and domain-specific problems developed by the Pythia community. Cookbooks build on top of skills you learn in [Pythia Foundations](https://foundations.projectpythia.org/).
 
 Cookbooks are created from Jupyter Notebooks that we strive to binderize so each Cookbook can be [executed in the cloud with a single click from your browser](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-notebooks-in-the-cloud-via-binder), but in some instances executing a Cookbook will require [running the notebooks locally](https://foundations.projectpythia.org/preamble/how-to-use.html#interacting-with-jupyter-books-locally).
 


### PR DESCRIPTION
Default link in gallery is incompatible with Mystification. This is a backwards compatible change.

"While I'm in here", remove this old config fallback. We don't want to rely on this, and want to know if any published cookbooks have this out of date config.